### PR TITLE
Log exceptions as annotations

### DIFF
--- a/source/Seq.App.VictorOps/Models/PostAlertOptions.cs
+++ b/source/Seq.App.VictorOps/Models/PostAlertOptions.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace Seq.App.VictorOps.Models
 {
@@ -12,5 +13,6 @@ namespace Seq.App.VictorOps.Models
         public string Id { get; set; }
         public bool TestMode { get; set; }
         public IDictionary<string, string> Properties { get; set; }
+        public string Exception { get; set; }
     }
 }

--- a/source/Seq.App.VictorOps/Models/VictorOpsAlert.cs
+++ b/source/Seq.App.VictorOps/Models/VictorOpsAlert.cs
@@ -22,6 +22,9 @@ namespace Seq.App.VictorOps
 
         [JsonProperty("state_message")]
         public string Message { get; set; }
+
+        [JsonProperty("vo_annotate.s.Exception")]
+        public string Exception { get; set; }
     }
 
     public enum AlertType

--- a/source/Seq.App.VictorOps/Seq.App.VictorOps.csproj
+++ b/source/Seq.App.VictorOps/Seq.App.VictorOps.csproj
@@ -8,6 +8,8 @@
     <PackageIconUrl>http://i.octopusdeploy.com/resources/Avatar3-32x32.png</PackageIconUrl>
     <PackageDescription>Sends messages received to the VictorOps REST endpoint</PackageDescription>
     <PackageLicenseUrl>https://github.com/OctopusDeploy/Seq.App.VictorOps/blob/master/LICENSE.txt</PackageLicenseUrl>
+    <RepositoryUrl>https://github.com/OctopusDeploy/Seq.App.VictorOps</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
     <PackageTags>seq-app seq events victorops</PackageTags>
   </PropertyGroup>
 

--- a/source/Seq.App.VictorOps/VictorOpsSeqApp.cs
+++ b/source/Seq.App.VictorOps/VictorOpsSeqApp.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using Seq.Apps;
 using Seq.Apps.LogEvents;
@@ -18,8 +19,6 @@ namespace Seq.App.VictorOps
             EnsureService();
 
             AlertType type = VictorOpsAlertTypeMapper.Map(evt.Data.Level);
-            StringBuilder sb = new StringBuilder(evt.Data.RenderedMessage);
-
             var postTask = _service.PostAlert(new PostAlertOptions
             {
                 Message = evt.Data.RenderedMessage,
@@ -29,7 +28,8 @@ namespace Seq.App.VictorOps
                 Type = type,
                 Id = evt.Id,
                 TestMode = TestMode,
-                Properties = evt.Data.Properties.ToDictionary(x => x.Key, x => x.Value?.ToString())
+                Properties = evt.Data.Properties.ToDictionary(x => x.Key, x => x.Value?.ToString()),
+                Exception = evt.Data.Exception ?? string.Empty
             });
             
             postTask.Wait();

--- a/source/Seq.App.VictorOps/VictorOpsService.cs
+++ b/source/Seq.App.VictorOps/VictorOpsService.cs
@@ -40,7 +40,7 @@ namespace Seq.App.VictorOps
             }
         }
 
-        private static string GetPayloadJson(PostAlertOptions options)
+        private string GetPayloadJson(PostAlertOptions options)
         {
             var payload = new VictorOpsAlert()
             {
@@ -50,7 +50,8 @@ namespace Seq.App.VictorOps
                 Message = options.Message,
                 Id = options.Id
             };
-
+            SetException(payload, options);
+            
             var jo = (JObject) JToken.FromObject(payload);
             foreach (var property in options.Properties)
             {
@@ -59,6 +60,14 @@ namespace Seq.App.VictorOps
 
             var payloadJson = JsonConvert.SerializeObject(jo);
             return payloadJson;
+        }
+
+        private void SetException(VictorOpsAlert payload, PostAlertOptions options)
+        {
+            if (!string.IsNullOrEmpty(options.Exception))
+            {
+                payload.Exception = options.Exception.Substring(0, 1124); // https://help.victorops.com/knowledge-base/rest-endpoint-integration-guide/#note-vo_annotate-s-note
+            }
         }
 
         private string GetVictorOpsUri(PostAlertOptions options)


### PR DESCRIPTION
[VictorOps docs](https://help.victorops.com/knowledge-base/rest-endpoint-integration-guide/#note-vo_annotate-s-note)

Updated payload:
```
{
    "message_type": "Critical",
    "monitoring_tool": "Seq",
    "entity_id": "event-8d896b02aa2908d710f8640000000000",
    "entity_display_name": "title",
    "state_message": "Error when running scheduled task: Octopus.Server.Schedules.RunOnAScheduleAdapter`1[Octopus.Server.Schedules.CheckTentacleHealth]",
    "vo_annotate.s.Exception": "System.Data.SqlClient.SqlException (0x80131904): A connection was successfully established with the server, but then an error occurred during the pre-login handshake. (provider: SSL Provider, error: 0 - The wait operation timed out.) ---> System.ComponentModel.Win32Exception (0x80004005): The wait operation timed out\\r\\n   at System.Data.SqlClient.SqlInternalConnectionTds..ctor(DbConnectionPoolIdentity identity, SqlConnectionString connectionOptions, SqlCredential credential, Object providerInfo, String newPassword, SecureString newSecurePassword, Boolean redirectedUserInstance, SqlConnectionString userConnectionOptions, SessionData reconnectSessionData, DbConnectionPool pool, String accessToken, Boolean applyTransientFaultHandling, SqlAuthenticationProviderManager sqlAuthProviderManager)\\r\\n   at System.Data.SqlClient.SqlConnectionFactory.CreateConnection(DbConnectionOptions options, DbConnectionPoolKey poolKey, Object poolGroupProviderInfo, DbConnectionPool pool, DbConnection owningConnection, DbConnectionOptions userOptions)\\r\\n   at System.Data.ProviderBase.DbConnectionFactory.CreatePooledConnection(DbConnect"
}
```